### PR TITLE
feat(eslint.config.js): add import/no-extraneous-dependencies rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,5 +5,8 @@ export default ryoppippi({
 	ignores: ['tests/**/*.svelte'],
 	typescript: {
 		tsconfigPath: './tsconfig.json',
+		overrides: {
+			'import/no-extraneous-dependencies': ['error'],
+		},
 	},
 });


### PR DESCRIPTION
This commit adds a new rule to the ESLint configuration. The rule,
'import/no-extraneous-dependencies', is set to 'error'. This will help
ensure that no unnecessary dependencies are imported into the project.
